### PR TITLE
Add handling of differernt device sector sizes (512B and 4KiB)

### DIFF
--- a/include/zmap.h
+++ b/include/zmap.h
@@ -55,11 +55,13 @@ struct control {
     uint8_t show_flags; /* cmd_line flag to show extent flags */
     uint8_t info;       /* cmd_line flag to show info */
 
-    unsigned int sector_size; /* Size of sectors on the ZNS device */
+    unsigned int sector_size;  /* Size of sectors on the ZNS device */
     unsigned int sector_shift; /* bit shift for sector conversion */
 
-    uint64_t f2fs_segment_sectors; /* how many logical sectors a segment has, depending on device LBA size */
-    uint64_t f2fs_segment_mask; /* the mask to apply for LBA to segment LBAS conversion, depnding on device LBA size */ 
+    uint64_t f2fs_segment_sectors; /* how many logical sectors a segment has,
+                                      depending on device LBA size */
+    uint64_t f2fs_segment_mask;    /* the mask to apply for LBA to segment LBAS
+                                      conversion, depnding on device LBA size */
     /*
      * F2FS Segments contain a power of 2 number of Sectors. Based on the device
      * sector size we can use bit shifts to convert between blocks and segments.

--- a/include/zmap.h
+++ b/include/zmap.h
@@ -25,19 +25,7 @@
 
 #include <linux/blkzoned.h>
 
-/*
- * Shift byte valus to 512B sector values.
- *
- * */
-#define SECTOR_SHIFT 9
-
-#define F2FS_BLOCK_SHIFT 12
-#define F2FS_BLOCK_BYTES 4096
-#define F2FS_BLOCK_MASK ~((F2FS_BLOCK_BYTES >> SECTOR_SHIFT) - 1)
-
 #define F2FS_SEGMENT_BYTES 2097152
-#define F2FS_SEGMENT_SECTORS (F2FS_SEGMENT_BYTES >> SECTOR_SHIFT)
-#define F2FS_SEGMENT_MASK (~((F2FS_SEGMENT_SECTORS)-1))
 
 #define MAX_FILE_LENGTH 50
 #define MAX_DEV_NAME 15
@@ -68,7 +56,10 @@ struct control {
     uint8_t info;       /* cmd_line flag to show info */
 
     unsigned int sector_size; /* Size of sectors on the ZNS device */
+    unsigned int sector_shift; /* bit shift for sector conversion */
 
+    uint64_t f2fs_segment_sectors; /* how many logical sectors a segment has, depending on device LBA size */
+    uint64_t f2fs_segment_mask; /* the mask to apply for LBA to segment LBAS conversion, depnding on device LBA size */ 
     /*
      * F2FS Segments contain a power of 2 number of Sectors. Based on the device
      * sector size we can use bit shifts to convert between blocks and segments.

--- a/lib/libzmap.c
+++ b/lib/libzmap.c
@@ -125,6 +125,13 @@ uint8_t init_znsdev() {
     close(fd);
 
     ctrl.sector_size = get_sector_size(ctrl.znsdev.dev_path);
+
+    // for F2FS both conventional and ZNS device must have same sector size
+    // therefore, we can assign one independent of which
+    ctrl.sector_shift = ctrl.sector_size == 512 ? 9: 12;
+    ctrl.f2fs_segment_sectors = F2FS_SEGMENT_BYTES >> ctrl.sector_shift;
+    ctrl.f2fs_segment_mask = ~(ctrl.f2fs_segment_sectors - 1);
+
     ctrl.segment_shift = ctrl.sector_size == 512 ? 12 : 9;
 
     return 1;
@@ -363,7 +370,7 @@ struct extent_map *get_extents() {
     fiemap->fm_flags = FIEMAP_FLAG_SYNC;
     fiemap->fm_start = 0;
     fiemap->fm_extent_count = 1; // get extents individually
-    fiemap->fm_length = (ctrl.stats->st_blocks << SECTOR_SHIFT);
+    fiemap->fm_length = (ctrl.stats->st_blocks << ctrl.sector_shift);
     extent_map->ext_ctr = 0;
 
     do {
@@ -390,11 +397,11 @@ struct extent_map *get_extents() {
                  "FILE %s\nExtent Reported on %s  PBAS: "
                  "0x%06llx  PBAE: 0x%06llx  SIZE: 0x%06llx\n",
                  ctrl.filename, ctrl.bdev.dev_name,
-                 fiemap->fm_extents[0].fe_physical >> SECTOR_SHIFT,
+                 fiemap->fm_extents[0].fe_physical >> ctrl.sector_shift,
                  (fiemap->fm_extents[0].fe_physical +
                   fiemap->fm_extents[0].fe_length) >>
-                     SECTOR_SHIFT,
-                 fiemap->fm_extents[0].fe_length >> SECTOR_SHIFT);
+                     ctrl.sector_shift,
+                 fiemap->fm_extents[0].fe_length >> ctrl.sector_shift);
 
             if (ctrl.log_level > 1 && ctrl.show_flags) {
                 show_extent_flags(fiemap->fm_extents[0].fe_flags);
@@ -404,11 +411,11 @@ struct extent_map *get_extents() {
                  "FILE %s\nExtent Reported on %s  PBAS: "
                  "0x%06llx  PBAE: 0x%06llx  SIZE: 0x%06llx\n",
                  ctrl.filename, ctrl.bdev.dev_name,
-                 fiemap->fm_extents[0].fe_physical >> SECTOR_SHIFT,
+                 fiemap->fm_extents[0].fe_physical >> ctrl.sector_shift,
                  (fiemap->fm_extents[0].fe_physical +
                   fiemap->fm_extents[0].fe_length) >>
-                     SECTOR_SHIFT,
-                 fiemap->fm_extents[0].fe_length >> SECTOR_SHIFT);
+                     ctrl.sector_shift,
+                 fiemap->fm_extents[0].fe_length >> ctrl.sector_shift);
 
             if (ctrl.log_level > 1) {
                 show_extent_flags(fiemap->fm_extents[0].fe_flags);
@@ -418,11 +425,11 @@ struct extent_map *get_extents() {
         } else {
             extent_map->extent[extent_map->ext_ctr].phy_blk =
                 (fiemap->fm_extents[0].fe_physical - ctrl.offset) >>
-                SECTOR_SHIFT;
+                ctrl.sector_shift;
             extent_map->extent[extent_map->ext_ctr].logical_blk =
-                fiemap->fm_extents[0].fe_logical >> SECTOR_SHIFT;
+                fiemap->fm_extents[0].fe_logical >> ctrl.sector_shift;
             extent_map->extent[extent_map->ext_ctr].len =
-                fiemap->fm_extents[0].fe_length >> SECTOR_SHIFT;
+                fiemap->fm_extents[0].fe_length >> ctrl.sector_shift;
             extent_map->extent[extent_map->ext_ctr].zone_size =
                 ctrl.znsdev.zone_size;
             extent_map->extent[extent_map->ext_ctr].ext_nr =
@@ -435,7 +442,7 @@ struct extent_map *get_extents() {
 
             extent_map->extent[extent_map->ext_ctr].zone = get_zone_number(
                 ((fiemap->fm_extents[0].fe_physical - ctrl.offset) >>
-                 SECTOR_SHIFT));
+                 ctrl.sector_shift));
             extent_map->extent[extent_map->ext_ctr].file =
                 calloc(1, sizeof(char) * MAX_FILE_LENGTH);
             memcpy(extent_map->extent[extent_map->ext_ctr].file, ctrl.filename,

--- a/lib/libzmap.c
+++ b/lib/libzmap.c
@@ -128,7 +128,7 @@ uint8_t init_znsdev() {
 
     // for F2FS both conventional and ZNS device must have same sector size
     // therefore, we can assign one independent of which
-    ctrl.sector_shift = ctrl.sector_size == 512 ? 9: 12;
+    ctrl.sector_shift = ctrl.sector_size == 512 ? 9 : 12;
     ctrl.f2fs_segment_sectors = F2FS_SEGMENT_BYTES >> ctrl.sector_shift;
     ctrl.f2fs_segment_mask = ~(ctrl.f2fs_segment_sectors - 1);
 

--- a/src/fs_info.c
+++ b/src/fs_info.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[]) {
     MSG("================================================================"
         "=\n");
 
-    uint64_t lba = nat_entry->block_addr << F2FS_BLKSIZE_BITS >> SECTOR_SHIFT;
+    uint64_t lba = nat_entry->block_addr << F2FS_BLKSIZE_BITS >> ctrl.sector_shift;
     uint32_t zone_number = get_zone_number(lba);
     MSG("\nFile %s with inode %u is located in zone %u\n", ctrl.filename,
         nat_entry->ino, zone_number);

--- a/src/fs_info.c
+++ b/src/fs_info.c
@@ -102,7 +102,8 @@ int main(int argc, char *argv[]) {
     MSG("================================================================"
         "=\n");
 
-    uint64_t lba = nat_entry->block_addr << F2FS_BLKSIZE_BITS >> ctrl.sector_shift;
+    uint64_t lba =
+        nat_entry->block_addr << F2FS_BLKSIZE_BITS >> ctrl.sector_shift;
     uint32_t zone_number = get_zone_number(lba);
     MSG("\nFile %s with inode %u is located in zone %u\n", ctrl.filename,
         nat_entry->ino, zone_number);

--- a/src/segmap.c
+++ b/src/segmap.c
@@ -188,7 +188,7 @@ static void show_segment_info(uint64_t segment_start) {
             "  SIZE: %#-10" PRIx64 "\n",
             segment_start, segment_start << ctrl.segment_shift,
             ((segment_start << ctrl.segment_shift) + ctrl.f2fs_segment_sectors),
-            (unsigned long)ctrl.f2fs_segment_sectors);
+            ctrl.f2fs_segment_sectors);
         if (ctrl.procfs) {
             show_segment_flags(segment_start, 0);
         }
@@ -330,8 +330,9 @@ static void show_segment_report() {
         "=\n");
 
     for (uint64_t i = 0; i < glob_extent_map->ext_ctr; i++) {
-        segment_id = (glob_extent_map->extent[i].phy_blk & ctrl.f2fs_segment_mask) >>
-                     ctrl.segment_shift;
+        segment_id =
+            (glob_extent_map->extent[i].phy_blk & ctrl.f2fs_segment_mask) >>
+            ctrl.segment_shift;
         if ((segment_id << ctrl.segment_shift) >= end_lba) {
             break;
         }

--- a/src/segmap.c
+++ b/src/segmap.c
@@ -168,7 +168,7 @@ static void show_segment_flags(uint32_t segment_id, uint8_t is_range) {
 
     MSG("  VALID BLOCKS: %3u",
         segman.sm_info[segment_id].valid_blocks << F2FS_BLKSIZE_BITS >>
-            SECTOR_SHIFT);
+            ctrl.sector_shift);
     if (is_range) {
         MSG(" per segment\n");
     } else {
@@ -187,8 +187,8 @@ static void show_segment_info(uint64_t segment_start) {
         MSG("SEGMENT: %-4lu  PBAS: %#-10" PRIx64 "  PBAE: %#-10" PRIx64
             "  SIZE: %#-10" PRIx64 "\n",
             segment_start, segment_start << ctrl.segment_shift,
-            ((segment_start << ctrl.segment_shift) + F2FS_SEGMENT_SECTORS),
-            (unsigned long)F2FS_SEGMENT_SECTORS);
+            ((segment_start << ctrl.segment_shift) + ctrl.f2fs_segment_sectors),
+            (unsigned long)ctrl.f2fs_segment_sectors);
         if (ctrl.procfs) {
             show_segment_flags(segment_start, 0);
         }
@@ -212,8 +212,8 @@ static void show_segment_info(uint64_t segment_start) {
  * */
 static void show_beginning_segment(uint64_t i) {
     uint64_t segment_start =
-        (glob_extent_map->extent[i].phy_blk & F2FS_SEGMENT_MASK);
-    uint64_t segment_end = segment_start + (F2FS_SEGMENT_SECTORS);
+        (glob_extent_map->extent[i].phy_blk & ctrl.f2fs_segment_mask);
+    uint64_t segment_end = segment_start + (ctrl.f2fs_segment_sectors);
 
     MSG("***** EXTENT:  PBAS: %#-10" PRIx64 "  PBAE: %#-10" PRIx64
         "  SIZE: %#-10" PRIx64 "  FILE: %50s  EXTID: %4d/%-4d\n",
@@ -235,7 +235,7 @@ static void show_beginning_segment(uint64_t i) {
 static void show_consecutive_segments(uint64_t i, uint64_t segment_start) {
     uint64_t segment_end =
         ((glob_extent_map->extent[i].phy_blk + glob_extent_map->extent[i].len) &
-         F2FS_SEGMENT_MASK) >>
+         ctrl.f2fs_segment_mask) >>
         ctrl.segment_shift;
     uint64_t num_segments = segment_end - segment_start;
 
@@ -248,7 +248,7 @@ static void show_consecutive_segments(uint64_t i, uint64_t segment_start) {
             "  SIZE: %#-10" PRIx64 "  FILE: %50s  EXTID: %4d/%-4d\n",
             glob_extent_map->extent[i].phy_blk,
             segment_end << ctrl.segment_shift,
-            (unsigned long)F2FS_SEGMENT_SECTORS,
+            (unsigned long)ctrl.f2fs_segment_sectors,
             glob_extent_map->extent[i].file,
             glob_extent_map->extent[i].ext_nr + 1,
             get_file_counter(glob_extent_map->extent[i].file));
@@ -263,7 +263,7 @@ static void show_consecutive_segments(uint64_t i, uint64_t segment_start) {
             "  PBAE: %#-10" PRIx64 "  SIZE: %#-10" PRIx64 "\n",
             segment_start, segment_end - 1, segment_start << ctrl.segment_shift,
             segment_end << ctrl.segment_shift,
-            num_segments * F2FS_SEGMENT_SECTORS);
+            num_segments * ctrl.f2fs_segment_sectors);
 
         // Since segments are in the same zone, they must be of the same type
         // therefore, we can just print the flags of the first one, and since
@@ -281,7 +281,7 @@ static void show_consecutive_segments(uint64_t i, uint64_t segment_start) {
             "  SIZE: %#-10" PRIx64 "  FILE: %50s  EXTID: %4d/%-4d\n",
             segment_start << ctrl.segment_shift,
             segment_end << ctrl.segment_shift,
-            num_segments * F2FS_SEGMENT_SECTORS,
+            num_segments * ctrl.f2fs_segment_sectors,
             glob_extent_map->extent[i].file,
             glob_extent_map->extent[i].ext_nr + 1,
             get_file_counter(glob_extent_map->extent[i].file));
@@ -296,7 +296,7 @@ static void show_consecutive_segments(uint64_t i, uint64_t segment_start) {
 static void show_remainder_segment(uint64_t i) {
     uint64_t segment_start =
         ((glob_extent_map->extent[i].phy_blk + glob_extent_map->extent[i].len) &
-         F2FS_SEGMENT_MASK) >>
+         ctrl.f2fs_segment_mask) >>
         ctrl.segment_shift;
     uint64_t remainder = glob_extent_map->extent[i].phy_blk +
                          glob_extent_map->extent[i].len -
@@ -330,7 +330,7 @@ static void show_segment_report() {
         "=\n");
 
     for (uint64_t i = 0; i < glob_extent_map->ext_ctr; i++) {
-        segment_id = (glob_extent_map->extent[i].phy_blk & F2FS_SEGMENT_MASK) >>
+        segment_id = (glob_extent_map->extent[i].phy_blk & ctrl.f2fs_segment_mask) >>
                      ctrl.segment_shift;
         if ((segment_id << ctrl.segment_shift) >= end_lba) {
             break;
@@ -352,13 +352,13 @@ static void show_segment_report() {
         }
 
         uint64_t segment_start =
-            (glob_extent_map->extent[i].phy_blk & F2FS_SEGMENT_MASK);
+            (glob_extent_map->extent[i].phy_blk & ctrl.f2fs_segment_mask);
 
         // if the beginning of the extent and the ending of the extent are in
         // the same segment
         if (segment_start == ((glob_extent_map->extent[i].phy_blk +
                                glob_extent_map->extent[i].len) &
-                              F2FS_SEGMENT_MASK)) {
+                              ctrl.f2fs_segment_mask)) {
             if (segment_id != ctrl.cur_segment) {
                 show_segment_info(segment_id);
                 ctrl.cur_segment = segment_id;
@@ -381,7 +381,7 @@ static void show_segment_report() {
                 if (segment_id != ctrl.cur_segment) {
                     uint64_t segment_start =
                         (glob_extent_map->extent[i].phy_blk &
-                         F2FS_SEGMENT_MASK) >>
+                         ctrl.f2fs_segment_mask) >>
                         ctrl.segment_shift;
                     show_segment_info(segment_start);
                 }
@@ -398,7 +398,7 @@ static void show_segment_report() {
             // remaining fragment
             uint64_t segment_end = ((glob_extent_map->extent[i].phy_blk +
                                      glob_extent_map->extent[i].len) &
-                                    F2FS_SEGMENT_MASK);
+                                    ctrl.f2fs_segment_mask);
             if (segment_end != glob_extent_map->extent[i].phy_blk +
                                    glob_extent_map->extent[i].len) {
                 show_remainder_segment(i);
@@ -578,7 +578,7 @@ int main(int argc, char *argv[]) {
     highest_segment =
         ((glob_extent_map->extent[glob_extent_map->ext_ctr - 1].phy_blk +
           glob_extent_map->extent[glob_extent_map->ext_ctr - 1].len) &
-         F2FS_SEGMENT_MASK) >>
+         ctrl.f2fs_segment_mask) >>
         ctrl.segment_shift;
     if (ctrl.procfs) {
         get_procfs_segment_bits(highest_segment);


### PR DESCRIPTION
F2FS enforces that both devices (conventional and ZNS) have the same sector size, but they can be 512B or 4KiB. Now we check these in the setup and initialize control variables to define bit shifts, address conversion, etc.