### PR TITLE
Fix racecondition segmap

### DIFF
--- a/src/segmap.c
+++ b/src/segmap.c
@@ -106,7 +106,13 @@ static void collect_extents(char *path) {
             fsync(ctrl.fd);
 
             if (ctrl.fd < 0) {
-                ERR_MSG("failed opening file %s\n", ctrl.filename);
+		// The file could have been deleted in the meantime.
+		if (access(ctrl.filename, F_OK) != 0) {
+			INFO(1, "File no longer exists: %s", ctrl.filename);
+			continue;
+		} else {
+                	ERR_MSG("failed opening file %s\n", ctrl.filename);
+		}
             }
 
             if (fstat(ctrl.fd, ctrl.stats) < 0) {

--- a/src/segmap.c
+++ b/src/segmap.c
@@ -106,13 +106,13 @@ static void collect_extents(char *path) {
             fsync(ctrl.fd);
 
             if (ctrl.fd < 0) {
-		// The file could have been deleted in the meantime.
-		if (access(ctrl.filename, F_OK) != 0) {
-			INFO(1, "File no longer exists: %s", ctrl.filename);
-			continue;
-		} else {
-                	ERR_MSG("failed opening file %s\n", ctrl.filename);
-		}
+                // The file could have been deleted in the meantime.
+                if (access(ctrl.filename, F_OK) != 0) {
+                    INFO(1, "File no longer exists: %s", ctrl.filename);
+                    continue;
+                } else {
+                    ERR_MSG("failed opening file %s\n", ctrl.filename);
+                }
             }
 
             if (fstat(ctrl.fd, ctrl.stats) < 0) {


### PR DESCRIPTION
Sometimes a file is deleted when segmap is printing out the file data.
This creates race conditions where fd < 0. It is better to quickly check if the file still exists before printing its extents.