### PR TITLE
fix memory issue in get_extents

### DIFF
--- a/zns-tools.fs/lib/libzns-tools.c
+++ b/zns-tools.fs/lib/libzns-tools.c
@@ -1,6 +1,5 @@
 #include "zns-tools.h"
 #include <stdlib.h>
-
 struct control ctrl;
 
 /*
@@ -565,7 +564,8 @@ int get_extents(char *filename, int fd, struct stat *stats) {
     uint64_t ext_ctr = 0;
     struct file_counter_map *temp = NULL;
 
-    fiemap = (struct fiemap *)calloc(sizeof(struct fiemap), sizeof(char *));
+    fiemap = calloc(1, sizeof(struct fiemap)
+		    + sizeof(struct fiemap_extent) * stats->st_blocks);
     extent = calloc(1, sizeof(struct extent));
 
     fiemap->fm_flags = FIEMAP_FLAG_SYNC;


### PR DESCRIPTION
Hello, I find a bug in `get_extents` function.

Refer to the [fiemap documentation](https://www.kernel.org/doc/Documentation/filesystems/fiemap.txt), size of `struct fiemap` must be big enough to hold all the requested extent informations.

But the original code only allocates `sizeof(char *) * sizeof(struct fiemap)` bytes of memory. I think this might cause a memory issue if the number of extent(`fm_exent_count`) is big enough, and maybe it is related to issue #89.

So I change the allocation size to hold all requested extents information.