### PR TITLE
Fix strncmp bug in segmap

### DIFF
--- a/zns-tools.fs/lib/libzns-tools.c
+++ b/zns-tools.fs/lib/libzns-tools.c
@@ -564,8 +564,8 @@ int get_extents(char *filename, int fd, struct stat *stats) {
     uint64_t ext_ctr = 0;
     struct file_counter_map *temp = NULL;
 
-    fiemap = calloc(1, sizeof(struct fiemap)
-		    + sizeof(struct fiemap_extent) * stats->st_blocks);
+    fiemap = calloc(1, sizeof(struct fiemap) +
+                           sizeof(struct fiemap_extent) * stats->st_blocks);
     extent = calloc(1, sizeof(struct extent));
 
     fiemap->fm_flags = FIEMAP_FLAG_SYNC;
@@ -742,7 +742,8 @@ int contains_element(uint32_t list[], uint32_t element, uint32_t size) {
  * */
 uint32_t get_file_extent_count(char *file) {
     for (uint32_t i = 0; i < ctrl.file_counter_map->file_ctr; i++) {
-        if (strncmp(ctrl.file_counter_map->files[i].file, file,
+        if (strlen(ctrl.file_counter_map->files[i].file) == strlen(file) &&
+            strncmp(ctrl.file_counter_map->files[i].file, file,
                     strlen(ctrl.file_counter_map->files[i].file)) == 0) {
             return ctrl.file_counter_map->files[i].ext_ctr;
         }
@@ -767,7 +768,8 @@ void increase_file_segment_counter(char *file, unsigned int num_segments,
     enum type type = seg_i->type;
 
     for (i = 0; i < ctrl.file_counter_map->file_ctr; i++) {
-        if (strncmp(ctrl.file_counter_map->files[i].file, file,
+        if (strlen(ctrl.file_counter_map->files[i].file) == strlen(file) &&
+            strncmp(ctrl.file_counter_map->files[i].file, file,
                     strlen(ctrl.file_counter_map->files[i].file)) == 0) {
             goto found;
         }

--- a/zns-tools.fs/src/segmap.c
+++ b/zns-tools.fs/src/segmap.c
@@ -275,8 +275,9 @@ static unsigned int get_file_stats_index(char *filename) {
     uint32_t i = 0;
 
     for (i = 0; i < segmap_man.ctr; i++) {
-        if (strncmp(segmap_man.fs[i].filename, filename, MAX_FILE_LENGTH) ==
-            0) {
+        if (strlen(segmap_man.fs[i].filename) == strlen(filename) &&
+            strncmp(segmap_man.fs[i].filename, filename, MAX_FILE_LENGTH) ==
+                0) {
             return i;
         }
     }


### PR DESCRIPTION
# Bugfix  #108 

## What was the error?:
Segment stats is incorrect as it does not always show all occupying segments or zones.
There is a logical error in our string comparison, causing filenames that are subset each other to be seen as equal (we only do a strncmp, not a size check). For example, `/mnt/test/1` is equal to `/mnt/test/1111`.

## Fix: 
We added a size check to our string comparisons. 